### PR TITLE
Fix create_backup and get_backup.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=python-pyunifi
-pkgver=r252.a60c150
+pkgver=r254.15e0645
 pkgrel=1
 pkgdesc='A rewrite of https://github.com/unifi-hackers/unifi-lab in cleaner Python.'
 arch=('any')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,27 @@
+pkgname=python-pyunifi
+pkgver=r252.a60c150
+pkgrel=1
+pkgdesc='A rewrite of https://github.com/unifi-hackers/unifi-lab in cleaner Python.'
+arch=('any')
+url='https://github.com/BoostCookie/pyunifi'
+license=('MIT')
+depends=('python-requests')
+makedepends=('python-setuptools')
+source=("${pkgname}::git+https://github.com/BoostCookie/pyunifi.git")
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$pkgname"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "$pkgname"
+    python setup.py build
+}
+
+package() {
+    cd "$pkgname"
+    python setup.py install --root="$pkgdir" --optimize=1
+}
+

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=python-pyunifi
-pkgver=r256.cf2c735
+pkgver=r257.468609d
 pkgrel=1
 pkgdesc='A rewrite of https://github.com/unifi-hackers/unifi-lab in cleaner Python.'
 arch=('any')
@@ -11,8 +11,8 @@ source=("${pkgname}::git+https://github.com/BoostCookie/pyunifi.git")
 md5sums=('SKIP')
 
 pkgver() {
-	cd "$pkgname"
-	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+    cd "$pkgname"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 build() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=python-pyunifi
-pkgver=r254.15e0645
+pkgver=r256.cf2c735
 pkgrel=1
 pkgdesc='A rewrite of https://github.com/unifi-hackers/unifi-lab in cleaner Python.'
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ then  be used to restore a controller on another machine.
 
 Remember that this puts significant load on a controller for some time (depending on the amount of users and managed APs).
 
-### `get_backup(self, targetfile)`
+### `get_backup(self, download_path=None, targetfile="unifi-backup.unf")`
 
 Tells the controller to create a backup archive and downloads it to a file. It should have a .unf extension for later restore.
-
- - `targetfile` -- the target file name, you can also use a full path. Default creates unifi-backup.unf in the current directoy.
+ - `download_path` -- the url of the `.unf` file to be downloaded. If this is `None` then `create_backup()` is called first.
+ - `targetfile` -- the target file name. You can also use a full path. Default creates unifi-backup.unf in the current directoy.
 
 ### `authorize_guest(self, guest_mac, minutes, up_bandwidth=None, down_bandwidth=None, byte_quota=None, ap_mac=None)`
 

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -546,7 +546,7 @@ class Controller:  # pylint: disable=R0902,R0904
 
         res = self._run_command(
             "backup",
-            mgr="system",
+            mgr="backup",
             params={"days": days}
             )
         return res[0]["url"]

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -569,7 +569,7 @@ class Controller:  # pylint: disable=R0902,R0904
 
         response = self.session.get(self.url + download_path, stream=True)
 
-        if response != 200:
+        if response.status_code != 200:
             raise APIError("API backup failed: %i" % response.status_code)
 
         with open(target_file, "wb") as _backfh:

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -861,3 +861,10 @@ class Controller:  # pylint: disable=R0902,R0904
         cmd = "delete-voucher"
         params = {"_id": voucher_id}
         self._run_command(cmd, mgr="hotspot", params=params)
+
+    def get_rogues(self, hours: int = 48):
+            """Return a list of rogue APs
+            """
+            params = {"within": hours}
+            return self._api_read("stat/rogueap", params)
+

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -9,6 +9,7 @@ import logging
 
 import requests
 from urllib3.exceptions import InsecureRequestWarning
+from typing import List, Dict
 
 
 """For testing purposes:
@@ -867,4 +868,17 @@ class Controller:  # pylint: disable=R0902,R0904
             """
             params = {"within": hours}
             return self._api_read("stat/rogueap", params)
+
+    def get_radius_profiles(self):
+        """
+        Return a list of radius profiles
+        """
+        return self._api_read("rest/radiusprofile")
+
+    def set_radius_auth_servers(self, _id: str, auth_servers: List[Dict]):
+        """
+        Return a list of radius profiles
+        """
+        params = {"auth_servers": auth_servers}
+        return self._api_update("rest/radiusprofile/" + _id, params)
 


### PR DESCRIPTION
Fixes https://github.com/finish06/pyunifi/issues/61 and more.

For create_backup the suggested solution from https://github.com/finish06/pyunifi/issues/61 was taken.

get_backup still failed, because
`if response != 200:`
was used instead of
`if response.status_code != 200:`.

The README.md was updated to contain both arguments for get_backup.