### PR TITLE
Update to new API, unify CLI, add functions for backup, autobackup and PSK handling

### DIFF
--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -552,6 +552,27 @@ class Controller:  # pylint: disable=R0902,R0904
         """Archive all Alerts"""
         return self._run_command("archive-all-alarms", mgr="evtmgr")
 
+    def list_autobackups(self):
+        backups = self._run_command(
+             "list-backups",
+             mgr="backup",
+             params={"cmd":"list-backups"}
+             )
+
+        sortedbackups = sorted(backups, key=lambda d: d['time'], reverse=True)
+        return sortedbackups
+
+    def get_last_autobackup(self, target_file=None):
+        backups = self.list_autobackups()
+        filename = backups[0]['filename']
+        download_path = 'dl/autobackup/' + filename
+        if not target_file:
+            target_file = filename
+
+        self.get_backup(download_path=download_path, target_file=target_file)
+        return target_file
+
+
     # TODO: Not currently supported on UDMP as it now utilizes async-backups.
     def create_backup(self, days="0"):
         """Ask controller to create a backup archive file

--- a/unifi-copy-radius
+++ b/unifi-copy-radius
@@ -21,7 +21,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-copy-radius
+++ b/unifi-copy-radius
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-  
+#!/usr/bin/env python3
+
 import argparse
 import json
 
@@ -15,13 +15,18 @@ parser.add_argument('-s', '--siteid', default='default', help='the source site I
 parser.add_argument('-S', '--siteid2', default='', help='the destination site ID, to copy to')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 args = parser.parse_args()
 
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
         ssl_verify = args.certificate
-        
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
 controller_source = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid,  ssl_verify=ssl_verify)
 controller_dest   = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid2, ssl_verify=ssl_verify)
 

--- a/unifi-create-backup
+++ b/unifi-create-backup
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+from pyunifi.controller import Controller
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--controller', default='unifi', help='the controller address (default "unifi")')
+parser.add_argument('-u', '--username', default='admin', help='the controller username (default("admin")')
+parser.add_argument('-p', '--password', default='', help='the controller password')
+parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
+parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
+parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-f', '--file', default='unifi-backup.unf', help='the filename for the backup')
+args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
+
+c.get_backup(target_file=args.file)

--- a/unifi-create-voucher
+++ b/unifi-create-voucher
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 
@@ -13,12 +13,17 @@ parser.add_argument('-v', '--version', default='v5', help='the controller base v
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 args = parser.parse_args()
 
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
         ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
 
 c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 
@@ -34,5 +39,5 @@ def format_code(string):
         return first_half + '-' + second_half
 
 voucher_code = format_code(code)
-        
+
 print(voucher_code)

--- a/unifi-create-voucher
+++ b/unifi-create-voucher
@@ -19,7 +19,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-disconnect-client
+++ b/unifi-disconnect-client
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 
@@ -11,11 +11,16 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
-parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 parser.add_argument('macs', metavar='MAC', nargs='+', help='Client MAC address(es)')
 args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-disconnect-client
+++ b/unifi-disconnect-client
@@ -20,7 +20,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-download-autobackup
+++ b/unifi-download-autobackup
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+
+from pyunifi.controller import Controller
+
+def credFromCredsDir(credname):
+    if "CREDENTIALS_DIRECTORY" in os.environ.keys():
+        credfilename = os.path.join(os.environ["CREDENTIALS_DIRECTORY"], credname)
+        try:
+            with open(credfilename, 'r') as credfile:
+                cred = credfile.read().rstrip()
+        except:
+            sys.stderr.write("Could not read cred {} from {}".format(credname, credfilename))
+            sys.exit(2)
+    else:
+        sys.stderr.write("CREDENTIALS_DIRECTORY environment not provided")
+        sys.exit(1)
+    return cred
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--controller', default='unifi', help='the controller address (default "unifi")')
+parser.add_argument('-u', '--username', default='admin', help='the controller username (default("admin")')
+parser.add_argument('-p', '--password', default='', help='the controller password')
+parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
+parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
+parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+    ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+apipassword = args.password
+if not apipassword:
+    apipassword = credFromCredsDir("api-password")
+
+c = Controller(args.controller, args.username, apipassword, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
+
+targetfile = c.get_last_autobackup()
+print("Got backup {}".format(targetfile))

--- a/unifi-get-psk
+++ b/unifi-get-psk
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import argparse
+from pyunifi.controller import Controller
+
+import io
+import qrcode
+import base64
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--controller', default='unifi', help='the controller address (default "unifi")')
+parser.add_argument('-u', '--username', default='admin', help='the controller username (default("admin")')
+parser.add_argument('-p', '--password', default='', help='the controller password')
+parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
+parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
+parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-W', '--wifi', default='', help='SSID or ID of wifi')
+parser.add_argument('-t', '--outputtype', default='text', help='output (text, image, html)')
+parser.add_argument('-o', '--output', default='', help='output filename')
+args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
+
+ssid = None
+psk = None
+
+wifis = c.get_wifi()
+for wifi in wifis:
+    if args.wifi == wifi["configuration"]["_id"] or args.wifi == wifi["configuration"]["name"]:
+        if "x_passphrase" in wifi["configuration"]:
+            ssid = wifi["configuration"]["name"]
+            psk = wifi["configuration"]["x_passphrase"]
+
+
+qr = qrcode.QRCode()
+qr.add_data("WIFI:T:WPA;S:{};P:{};;".format(ssid, psk))
+
+if args.outputtype == 'text':
+    if not args.output:
+        print("\nWiFi Network Name: {}\nWiFi Password: {}\n\n".format(ssid, psk))
+        qr.print_tty()
+    else:
+        f = io.StringIO()
+        qr.print_ascii(out=f)
+        f.seek(0)
+        with open(args.output, 'w') as outfilehandle:
+            outfilehandle.write(f.read)
+
+elif args.outputtype == 'image':
+    if not args.output:
+        print('You need to supply an image filename')
+    else:
+        qr.make_image().save(args.output)
+
+
+elif args.outputtype == 'html':
+    buffer = io.BytesIO()
+    qr.make_image().save(buffer, format='PNG')
+    buffer.seek(0)
+    data_uri = base64.b64encode(buffer.read()).decode('ascii')
+    html = '<html><head></head><body>'
+    html += '<img src="data:image/png;base64,{0}">'.format(data_uri)
+    html += '</body></html>'
+
+    if not args.output:
+        print(html)
+    else:
+        with open(args.output, 'w') as outfilehandle:
+            outfilehandle.write(html)
+
+else:
+    print('outputtype {} is not known'.format(args.outputtype))

--- a/unifi-log-roaming
+++ b/unifi-log-roaming
@@ -22,7 +22,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-log-roaming
+++ b/unifi-log-roaming
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -14,9 +14,21 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 args = parser.parse_args()
 
-c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid)
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 
 aps = c.get_aps()
 ap_names = dict([(ap['mac'], ap.get('name')) for ap in aps])

--- a/unifi-low-snr-reconnect
+++ b/unifi-low-snr-reconnect
@@ -26,7 +26,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-low-snr-reconnect
+++ b/unifi-low-snr-reconnect
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -19,9 +19,20 @@ parser.add_argument('-m', '--minsnr', default=15, type=int, help='(dB) minimum r
 parser.add_argument('-i', '--checkintv', default=5, type=int, help='(s) check interval (default 5)')
 parser.add_argument('-o', '--holdintv', default=300, type=int, help='(s) holddown interval (default 300)')
 parser.add_argument('-d', '--debug', help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 args = parser.parse_args()
 
-c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid)
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 
 all_aps = c.get_aps()
 ap_names = dict([(ap['mac'], ap.get('name')) for ap in all_aps])
@@ -40,7 +51,7 @@ while True:
         mac = sta['mac']
         ap_mac = sta['ap_mac']
         ap_name = ap_names[ap_mac]
-	essid = sta['essid']
+        essid = sta['essid']
         if args.debug:
             print('%s/%s@%s %d' % (name, mac, ap_name, snr))
         if snr < args.minsnr:
@@ -55,4 +66,3 @@ while True:
                     print('Ignoring %s/%s@%s (SNR %d dB < %d dB) (holddown)' % (name, mac, ap_name, snr, args.minsnr))
 
     time.sleep(args.checkintv)
-

--- a/unifi-ls-aps
+++ b/unifi-ls-aps
@@ -21,7 +21,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-ls-aps
+++ b/unifi-ls-aps
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+from pyunifi.controller import Controller
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--controller', default='unifi', help='the controller address (default "unifi")')
+parser.add_argument('-u', '--username', default='admin', help='the controller username (default("admin")')
+parser.add_argument('-p', '--password', default='', help='the controller password')
+parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
+parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
+parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-f', '--file', default='statistics-unifi.csv', help='the filename of write statistics')
+args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
+
+for ap in c.get_aps():
+    print('AP named %s with MAC %s' % (ap.get('name'), ap['mac']))

--- a/unifi-ls-clients
+++ b/unifi-ls-clients
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 
@@ -11,6 +11,7 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 args = parser.parse_args()
@@ -19,6 +20,10 @@ ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
         ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
 
 c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 

--- a/unifi-ls-clients
+++ b/unifi-ls-clients
@@ -19,7 +19,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-ls-radius
+++ b/unifi-ls-radius
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 
@@ -11,6 +11,7 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 args = parser.parse_args()
@@ -19,6 +20,10 @@ ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
         ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
 
 c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 

--- a/unifi-ls-radius
+++ b/unifi-ls-radius
@@ -19,7 +19,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-save-radius
+++ b/unifi-save-radius
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 
@@ -11,6 +11,7 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
 parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
 parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 parser.add_argument('-f', '--file', default='radius-unifi.csv', help='the filename of write statistics')
@@ -20,6 +21,10 @@ ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
         ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
 
 c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 

--- a/unifi-save-radius
+++ b/unifi-save-radius
@@ -20,7 +20,7 @@ args = parser.parse_args()
 ssl_verify = (not args.no_ssl_verify)
 
 if ssl_verify and len(args.certificate) > 0:
-        ssl_verify = args.certificate
+    ssl_verify = args.certificate
 
 if args.debug:
     import logging

--- a/unifi-save-statistics
+++ b/unifi-save-statistics
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import time
@@ -12,10 +12,22 @@ parser.add_argument('-p', '--password', default='', help='the controller passwor
 parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
 parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
 parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
 parser.add_argument('-f', '--file', default='statistics-unifi.csv', help='the filename of write statistics')
 args = parser.parse_args()
 
-c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid)
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
 
 statistics = c.get_statistics_last_24h()
 

--- a/unifi-set-psk
+++ b/unifi-set-psk
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+from pyunifi.controller import Controller
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--controller', default='unifi', help='the controller address (default "unifi")')
+parser.add_argument('-u', '--username', default='admin', help='the controller username (default("admin")')
+parser.add_argument('-p', '--password', default='', help='the controller password')
+parser.add_argument('-b', '--port', default='8443', help='the controller port (default "8443")')
+parser.add_argument('-v', '--version', default='v5', help='the controller base version (default "v5")')
+parser.add_argument('-s', '--siteid', default='default', help='the site ID, UniFi >=3.x only (default "default")')
+parser.add_argument('-d', '--debug', default=False, help='enable debug output', action='store_true')
+parser.add_argument('-V', '--no-ssl-verify', default=False, action='store_true', help='Don\'t verify ssl certificates')
+parser.add_argument('-C', '--certificate', default='', help='verify with ssl certificate pem file')
+parser.add_argument('-W', '--wifi', default='', help='SSID or ID of wifi')
+parser.add_argument('-P', '--psk', default='', help='new PSK for wifi')
+args = parser.parse_args()
+
+ssl_verify = (not args.no_ssl_verify)
+
+if ssl_verify and len(args.certificate) > 0:
+        ssl_verify = args.certificate
+
+if args.debug:
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
+c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=ssl_verify)
+
+wifis = c.get_wifi()
+for wifi in wifis:
+    if args.wifi == wifi["configuration"]["_id"] or args.wifi == wifi["configuration"]["name"]:
+        if "x_passphrase" in wifi["configuration"]:
+            wifi["configuration"]["x_passphrase"] = args.psk
+            c.set_wifi(wifi["configuration"]["_id"], wifi["configuration"])


### PR DESCRIPTION
This pull request adds support for the APIv2 and various functions, complete with examples

- change shebang to python3
- update library for current unifi API
- adjust parameters of other example scripts to provide the same command line interface (--debug, --no-ssl-verify, --certificate)
- example script to list access points
- library support to create and download backups, with example script
- library support to download autobackups, with example script
- library support to read and change PSK of a network by name or UUID, with example script
