### PR TITLE
Add for_hotspot flag to Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Create a Controller object.
  - `version`	-- the base version of the controller API [v4|v5|unifiOS|UDMP-unifiOS]
  - `site_id`	-- the site ID to access
  - `ssl_verify`	-- Verify the controllers SSL certificate, default=True, can also be False or "path/to/custom_cert.pem"
+ - `for_hotspot` -- flag that the credentials are for a hotspot operator account
 
 ### `block_client(self, mac)`
 

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -69,6 +69,7 @@ class Controller:  # pylint: disable=R0902,R0904
             version="v5",
             site_id="default",
             ssl_verify=True,
+            for_hotspot=False,
     ):
         """
         :param host: the address of the controller host; IP or name
@@ -91,6 +92,7 @@ class Controller:  # pylint: disable=R0902,R0904
         self.password = password
         self.site_id = site_id
         self.ssl_verify = ssl_verify
+        self.for_hotspot = for_hotspot
 
         if version == "unifiOS":
             self.url = "https://" + host + "/proxy/network/"
@@ -182,9 +184,13 @@ class Controller:  # pylint: disable=R0902,R0904
         self.session = requests.Session()
         self.session.verify = self.ssl_verify
 
+        params = {"username": self.username, "password": self.password}
+        if self.for_hotspot:
+            params.update({"for_hotspot": True, "site_id": self.site_id})
+
         response = self.session.post(
             self.auth_url,
-            json={"username": self.username, "password": self.password},
+            json=params,
             headers=self.headers,
         )
 

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -188,7 +188,7 @@ class Controller:  # pylint: disable=R0902,R0904
 
         params = {"username": self.username, "password": self.password}
         if self.for_hotspot:
-            params.update({"for_hotspot": True, "site_id": self.site_id})
+            params.update({"for_hotspot": True, "site_name": self.site_id})
 
         response = self.session.post(
             self.auth_url,

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -80,6 +80,8 @@ class Controller:  # pylint: disable=R0902,R0904
         :param site_id: the site ID to connect to
         :param ssl_verify: Verify the controllers SSL certificate,
             can also be "path/to/custom_cert.pem"
+        :param for_hotspot: flag that the credentials are for a hotspot
+            operator account
         """
 
         self.log = logging.getLogger(__name__ + ".Controller")

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ skip_missing_interpreters = True
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pyunifi
-whitelist_externals = /usr/bin/env
+whitelist_externals = /usr/bin/
+allowlist_externals = /usr/bin/env
 install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
      py.test --timeout=30 --duration=10 --cov --cov-report= {posargs}


### PR DESCRIPTION
Controller._login() fails if the username/password combo are only configured as a
    "Hotspot Operator" account.